### PR TITLE
Fix setup.py CLI

### DIFF
--- a/dorothy/__init__.py
+++ b/dorothy/__init__.py
@@ -25,7 +25,7 @@ import yaml
 import dorothy.modules
 from .core import setup_logging
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 ROOT_DIR = Path(__file__).parent
 DATA_DIR = Path.home() / "dorothy" / "data"

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     install_requires=open("requirements.txt", "r").read(),
     entry_points={
         "console_scripts": [
-            "dorothy=dorothy.main:main",  # this registers a command line tool "dorothy"
+            "dorothy=dorothy.main:dorothy_shell",  # this registers a command line tool "dorothy"
         ],
     },
 )


### PR DESCRIPTION
## Issues
None

## Summary
Fixed the entry point for `dorothy` command. Before I had this
```console
$ dorothy
Traceback (most recent call last):
  File "/Users/rwolf/.conda/envs/py37/bin/dorothy", line 5, in <module>
    from dorothy.main import main
ImportError: cannot import name 'main' from 'dorothy.main' (.../lib/python3.7/site-packages/dorothy/main.py)
```

Now:
```console
$ dorothy

██████   ██████  ██████   ██████  ████████ ██   ██ ██    ██
██   ██ ██    ██ ██   ██ ██    ██    ██    ██   ██  ██  ██
██   ██ ██    ██ ██████  ██    ██    ██    ███████   ████
██   ██ ██    ██ ██   ██ ██    ██    ██    ██   ██    ██
██████   ██████  ██   ██  ██████     ██    ██   ██    ██

A tool to test security monitoring and detection for Okta environments

Created by David French (@threatpunter) at Elastic

Caution: Dorothy can change the configuration of your Okta environment
Consider using Dorothy in a test environment to avoid any risk of impacting your production environment
```
## Contributor checklist

- Have you followed the [contributor guidelines](https://github.com/elastic/dorothy/blob/main/CONTRIBUTING.md)?
